### PR TITLE
fix: blank issues can now be created easily

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Ask Questions in discord
     url: https://discord.gg/mwA8uP8CMc


### PR DESCRIPTION
Issues should be easy to create, unless there is a reason to filter them (which is not the case yet here).