### PR TITLE
fix: nightly tag now fast-forwards correctly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Delete nightly tag
       continue-on-error: true
-      run: git push --delete origin ${{ env.NIGHTLY_TAG }} || true
+      run: gh api --method DELETE repos/${{ github.repository }}/git/refs/tags/${{ env.NIGHTLY_TAG }} || true
       env:
         GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- Fixed the nightly workflow to properly delete and recreate the `nightly` tag on each run
- The tag was stuck at an old commit because the deletion step was failing silently

## Problem
The `nightly` tag was not moving forward with new commits (stuck at `4a53d31`, many commits behind HEAD). The nightly workflow's cleanup job attempted to delete the old tag using `git push --delete`, but this command failed silently because there was no git repository checked out in that job.

## Solution
Replaced the git command with a GitHub API call using `gh api --method DELETE`, which:
- Doesn't require a git checkout
- Matches the approach used for deleting the release
- Will properly delete the tag before creating a new one

## Test plan
- [x] Verify the workflow syntax is correct
- [ ] Wait for next nightly run (or manually trigger) to confirm the tag moves to HEAD
- [ ] Check that the nightly release is created successfully with updated tag

Fixes #129