### PR TITLE
fix: latest/download in release notes

### DIFF
--- a/.github/workflows/_build-image.yaml
+++ b/.github/workflows/_build-image.yaml
@@ -286,7 +286,7 @@ jobs:
           echo "4. Select **Use custom URL**, copy and paste the following _latest_ URL (ending with .json):" >> release-notes.md
           echo "" >> release-notes.md
           echo '```' >> release-notes.md
-          echo "https://github.com/${{ github.repository }}/releases/download/latest/${{ steps.generate_json.outputs.json_filename }}" >> release-notes.md
+          echo "https://github.com/${{ github.repository }}/releases/latest/download/${{ steps.generate_json.outputs.json_filename }}" >> release-notes.md
           echo '```' >> release-notes.md
           echo "Or select this release specifically:" >> release-notes.md
           echo '```' >> release-notes.md


### PR DESCRIPTION
A small fix in the generated release notes. The JSON file for latest URL gave 404 because the latest/download part in URL was swapped.

## Description
Swap download/latest with latest/download to make the URL correct